### PR TITLE
Add flag ReadCompressed to gcs.ReadObjectRequest (#34)

### DIFF
--- a/gcs/requests.go
+++ b/gcs/requests.go
@@ -189,6 +189,10 @@ type ReadObjectRequest struct {
 
 	// If present, limit the contents returned to a range within the object.
 	Range *ByteRange
+
+	// If present, read the contents of the GCS object as it is on GCS.
+	// This might not be honoured by all the implementations.
+	ReadCompressed bool
 }
 
 type StatObjectRequest struct {


### PR DESCRIPTION
This is a boolean flag added to gcs.ReadObjectRequest to allow caller to indicate the need to read the object content as compressed from the bucket interface. It is meant only for objects which have 'content-encoding' set to 'gzip' in their GCS metadata. The bucket implementation can accordingly take care of creating the read-request or of handling the request-response on the basis of this flag.